### PR TITLE
Add translations for Impressum and Privacy pages

### DIFF
--- a/src/app/[locale]/impressum/page.tsx
+++ b/src/app/[locale]/impressum/page.tsx
@@ -1,58 +1,89 @@
 'use client';
 
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 
 export default function ImpressumPage() {
+  const params = useParams();
+  const locale = params.locale as string;
+  
+  // Übersetzungen
+  const t = (key: string) => {
+    const translations = {
+      de: {
+        'title': 'Impressum',
+        'subtitle': 'Platzhalter-Inhalt. Hier stehen künftig die gesetzlich vorgeschriebenen Angaben gemäß § 5 TMG.',
+        'tmg': 'Angaben gemäß § 5 TMG',
+        'tmgText': 'Diese Seite ist eine vorläufige Impressum-Seite. Sie wird in Kürze durch eine vollständige und rechtskonforme Fassung ersetzt. Bis dahin gelten die allgemeinen Bestimmungen.',
+        'responsible': 'Verantwortlich für den Inhalt',
+        'responsibleText': 'Die Inhalte dieser Website werden nach bestem Wissen und Gewissen erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der bereitgestellten Informationen kann jedoch keine Gewähr übernommen werden.',
+        'disclaimer': 'Haftungsausschluss',
+        'disclaimerText': 'Diese Website dient ausschließlich zu Informationszwecken. Die Nutzung der bereitgestellten Inhalte erfolgt auf eigene Gefahr. Es wird keine Haftung für Schäden übernommen, die durch die Nutzung dieser Website entstehen könnten.',
+        'contact': 'Kontakt',
+        'contactText': 'Bei Fragen oder Anregungen können Sie uns gerne über die auf der Website angegebenen Kontaktmöglichkeiten erreichen.',
+        'backToHome': '← Zurück zur Startseite'
+      },
+      en: {
+        'title': 'Imprint',
+        'subtitle': 'Placeholder content. Here will be the legally required information according to § 5 TMG.',
+        'tmg': 'Information according to § 5 TMG',
+        'tmgText': 'This is a preliminary imprint page. It will soon be replaced by a complete and legally compliant version. Until then, the general provisions apply.',
+        'responsible': 'Responsible for content',
+        'responsibleText': 'The contents of this website are created to the best of our knowledge and belief. However, no guarantee can be given for the accuracy, completeness and timeliness of the information provided.',
+        'disclaimer': 'Disclaimer',
+        'disclaimerText': 'This website is for informational purposes only. The use of the provided content is at your own risk. No liability is assumed for damages that may arise from the use of this website.',
+        'contact': 'Contact',
+        'contactText': 'If you have any questions or suggestions, please feel free to contact us via the contact options provided on the website.',
+        'backToHome': '← Back to homepage'
+      }
+    };
+    return translations[locale as keyof typeof translations]?.[key as keyof typeof translations.de] || translations.de[key as keyof typeof translations.de];
+  };
+
   return (
     <div className="min-h-screen pt-20 px-4">
       <section className="max-w-4xl mx-auto">
-        <h1 className="heading-2 text-white mb-4">📝 Impressum</h1>
+        <h1 className="heading-2 text-white mb-4">📝 {t('title')}</h1>
         <p className="body-lg text-white/80 mb-8">
-          Platzhalter-Inhalt. Hier stehen künftig die gesetzlich vorgeschriebenen Angaben gemäß § 5 TMG.
+          {t('subtitle')}
         </p>
 
         <div className="space-y-6 body-base text-white/80">
           <div className="card-elevated p-6">
-            <h2 className="heading-3 text-white mb-4">Angaben gemäß § 5 TMG</h2>
+            <h2 className="heading-3 text-white mb-4">{t('tmg')}</h2>
             <p>
-              Diese Seite ist eine vorläufige Impressum-Seite. Sie wird in Kürze durch eine vollständige
-              und rechtskonforme Fassung ersetzt. Bis dahin gelten die allgemeinen Bestimmungen.
+              {t('tmgText')}
             </p>
           </div>
 
           <div className="card-elevated p-6">
-            <h2 className="heading-3 text-white mb-4">Verantwortlich für den Inhalt</h2>
+            <h2 className="heading-3 text-white mb-4">{t('responsible')}</h2>
             <p>
-              Die Inhalte dieser Website werden nach bestem Wissen und Gewissen erstellt. 
-              Für die Richtigkeit, Vollständigkeit und Aktualität der bereitgestellten Informationen 
-              kann jedoch keine Gewähr übernommen werden.
+              {t('responsibleText')}
             </p>
           </div>
 
           <div className="card-elevated p-6">
-            <h2 className="heading-3 text-white mb-4">Haftungsausschluss</h2>
+            <h2 className="heading-3 text-white mb-4">{t('disclaimer')}</h2>
             <p>
-              Diese Website dient ausschließlich zu Informationszwecken. Die Nutzung der 
-              bereitgestellten Inhalte erfolgt auf eigene Gefahr. Es wird keine Haftung für 
-              Schäden übernommen, die durch die Nutzung dieser Website entstehen könnten.
+              {t('disclaimerText')}
             </p>
           </div>
 
           <div className="card-elevated p-6">
-            <h2 className="heading-3 text-white mb-4">Kontakt</h2>
+            <h2 className="heading-3 text-white mb-4">{t('contact')}</h2>
             <p>
-              Bei Fragen oder Anregungen können Sie uns gerne über die auf der Website 
-              angegebenen Kontaktmöglichkeiten erreichen.
+              {t('contactText')}
             </p>
           </div>
         </div>
 
         <div className="mt-8 text-center">
           <Link 
-            href="/" 
+            href={`/${locale}`} 
             className="btn-primary px-6 py-3"
           >
-            ← Zurück zur Startseite
+            {t('backToHome')}
           </Link>
         </div>
       </section>

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -1,30 +1,75 @@
 'use client';
 
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
 export default function PrivacyPage() {
+  const params = useParams();
+  const locale = params.locale as string;
+  
+  // Übersetzungen
+  const t = (key: string) => {
+    const translations = {
+      de: {
+        'title': 'Datenschutz',
+        'subtitle': 'Platzhalter-Inhalt. Hier stehen künftig Informationen gemäß DSGVO zur Datenverarbeitung, Verantwortlichem, Speicherdauer, Rechtsgrundlagen, Betroffenenrechten und Kontaktmöglichkeiten.',
+        'preliminary': 'Diese Seite ist eine vorläufige Datenschutzerklärung. Sie wird in Kürze durch eine vollständige und rechtskonforme Fassung ersetzt. Bis dahin verarbeiten wir Daten ausschließlich im Rahmen der technischen Bereitstellung dieser Webseite.',
+        'responsible': 'Verantwortlicher: Wird ergänzt',
+        'purposes': 'Zwecke der Verarbeitung: Betrieb der Website, Sicherheit, Performance',
+        'legalBasis': 'Rechtsgrundlagen: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse)',
+        'recipients': 'Empfänger: Hosting- und Infrastrukturpartner',
+        'storage': 'Speicherdauer: Logdaten i. d. R. 7–14 Tage',
+        'rights': 'Betroffenenrechte: Auskunft, Berichtigung, Löschung, Einschränkung, Widerspruch',
+        'contact': 'Kontakt: Wird ergänzt',
+        'backToHome': '← Zurück zur Startseite'
+      },
+      en: {
+        'title': 'Privacy Policy',
+        'subtitle': 'Placeholder content. Here will be information according to GDPR on data processing, responsible party, storage duration, legal basis, data subject rights and contact options.',
+        'preliminary': 'This is a preliminary privacy policy. It will soon be replaced by a complete and legally compliant version. Until then, we process data exclusively within the framework of the technical provision of this website.',
+        'responsible': 'Responsible party: To be added',
+        'purposes': 'Purposes of processing: Website operation, security, performance',
+        'legalBasis': 'Legal basis: Art. 6 para. 1 lit. f GDPR (legitimate interest)',
+        'recipients': 'Recipients: Hosting and infrastructure partners',
+        'storage': 'Storage duration: Log data usually 7-14 days',
+        'rights': 'Data subject rights: Information, correction, deletion, restriction, objection',
+        'contact': 'Contact: To be added',
+        'backToHome': '← Back to homepage'
+      }
+    };
+    return translations[locale as keyof typeof translations]?.[key as keyof typeof translations.de] || translations.de[key as keyof typeof translations.de];
+  };
+
   return (
     <div className="min-h-screen pt-20 px-4">
       <section className="max-w-4xl mx-auto">
-        <h1 className="heading-2 text-white mb-4">📋 Datenschutz</h1>
+        <h1 className="heading-2 text-white mb-4">📋 {t('title')}</h1>
         <p className="body-lg text-white/80 mb-8">
-          Platzhalter-Inhalt. Hier stehen künftig Informationen gemäß DSGVO zur Datenverarbeitung,
-          Verantwortlichem, Speicherdauer, Rechtsgrundlagen, Betroffenenrechten und Kontaktmöglichkeiten.
+          {t('subtitle')}
         </p>
 
         <div className="space-y-6 body-base text-white/80">
           <p>
-            Diese Seite ist eine vorläufige Datenschutzerklärung. Sie wird in Kürze durch eine vollständige
-            und rechtskonforme Fassung ersetzt. Bis dahin verarbeiten wir Daten ausschließlich im Rahmen
-            der technischen Bereitstellung dieser Webseite.
+            {t('preliminary')}
           </p>
           <ul className="list-disc pl-6">
-            <li>Verantwortlicher: Wird ergänzt</li>
-            <li>Zwecke der Verarbeitung: Betrieb der Website, Sicherheit, Performance</li>
-            <li>Rechtsgrundlagen: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse)</li>
-            <li>Empfänger: Hosting- und Infrastrukturpartner</li>
-            <li>Speicherdauer: Logdaten i. d. R. 7–14 Tage</li>
-            <li>Betroffenenrechte: Auskunft, Berichtigung, Löschung, Einschränkung, Widerspruch</li>
-            <li>Kontakt: Wird ergänzt</li>
+            <li>{t('responsible')}</li>
+            <li>{t('purposes')}</li>
+            <li>{t('legalBasis')}</li>
+            <li>{t('recipients')}</li>
+            <li>{t('storage')}</li>
+            <li>{t('rights')}</li>
+            <li>{t('contact')}</li>
           </ul>
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link 
+            href={`/${locale}`} 
+            className="btn-primary px-6 py-3"
+          >
+            {t('backToHome')}
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/ui/Footer.tsx
+++ b/src/app/ui/Footer.tsx
@@ -3,11 +3,12 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 // import { CommunityStats } from "./CommunityStats"; // Unused import
 
 export function Footer() {
-  // const locale = useLocale();
-  // const t = useTranslations('Footer');
+  const pathname = usePathname();
+  const locale = pathname.startsWith('/en') ? 'en' : 'de';
   
   const [isClient, setIsClient] = useState(false);
 
@@ -139,13 +140,13 @@ export function Footer() {
             <h4 className="text-lg font-bold text-yellow-300 mb-4">ℹ️ Info</h4>
             <ul className="space-y-2">
                <li>
-                 <Link href="/privacy" className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">📋 Datenschutz</Link>
+                 <Link href={`/${locale}/privacy`} className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">📋 {locale === 'en' ? 'Privacy' : 'Datenschutz'}</Link>
                </li>
                 <li>
-                  <Link href="/impressum" className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">📝 Impressum</Link>
+                  <Link href={`/${locale}/impressum`} className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">📝 {locale === 'en' ? 'Imprint' : 'Impressum'}</Link>
                 </li>
                <li>
-                 <Link href="/faq" className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">❓ FAQ</Link>
+                 <Link href={`/${locale}/faq`} className="text-white/70 hover:text-yellow-300 transition-colors duration-200 text-sm font-medium">❓ FAQ</Link>
                </li>
               <li>
                 <span className="text-white/50 text-sm">📞 Kontakt</span>


### PR DESCRIPTION
- Add German/English translations for Impressum page
- Add German/English translations for Privacy page
- Fix Footer links to include locale prefix
- Both pages now work correctly in both languages
- Resolves routing issues for English version